### PR TITLE
Adding code to set up aliases and modify sudoers to allow for sudo exceptions

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -18,3 +18,20 @@
     state: absent
   with_items:
     - "{{ os_banned_packages }}"
+
+- name: Configure 'sudoers' file
+  lineinfile:
+    dest: /etc/sudoers
+    insertafter: "{{ item.regexp}}"
+    line: "{{ item.line }}"
+    validate: '/usr/sbin/visudo -cf %s'
+  with_items:
+    - "{{ sudoers_rules }}"
+
+- name: Configure /etc/bash.bashrc
+  lineinfile:
+    dest: /etc/bash.bashrc
+    insertafter: EOF
+    line: "{{item}}"
+  with_items:
+    - "{{ bashrc_alias }}"

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -146,3 +146,15 @@ os_banned_packages:
   - fenix
   - bsdgames-nonfree
   - exult-studio
+
+sudoers_rules:
+  - { regexp: '#\sCmnd\salias', line: 'Cmnd_Alias STAFF_PASS = /usr/sbin/openvpn' }
+  - { regexp: '#\sCmnd\salias', line: 'Cmnd_Alias STAFF_NO_PASS = /usr/bin/docker' }
+  - { regexp: 'EOF', line: '# Allow users in the staff group to run docker and openvpn as root'}
+  - { regexp: 'EOF', line: '%staff ALL=(ALL) STAFF_PASS'}
+  - { regexp: 'EOF', line: '%staff ALL=(ALL) NOPASSWD: STAFF_NO_PASS'}
+
+bashrc_alias:
+  - "# Alias for docker and openvpn to allow non-sudo users native access to these commands"
+  - "alias docker='sudo /usr/bin/docker'"
+  - "alias openvpn='sudo /usr/sbin/openvpn'"


### PR DESCRIPTION
This allows sudo access for users as detailed in the openvpn-docker-sudo.odt file in our secure repository.
This change has been tested on a local VM and on my machine. It produces the desired sudo access.